### PR TITLE
修复因pod重启后,导致的日志重复问题

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"pilot"
+	"github.com/AliyunContainerService/log-pilot/pilot"
 	log "github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"os"

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"github.com/AliyunContainerService/log-pilot/pilot"
+	"pilot"
 	log "github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"os"

--- a/pilot/pilot.go
+++ b/pilot/pilot.go
@@ -449,7 +449,8 @@ func (p *Pilot) processEvent(msg events.Message) error {
 		}
 
 		return p.newContainer(&containerJSON)
-	case "destroy":
+	//Increase the monitoring of container Exit events and repair the log duplicate collection caused by the failure to delete the exited container in time
+	case "destroy" , "die" :
 		log.Debugf("Process container destroy event: %s", containerId)
 
 		err := p.delContainer(containerId)


### PR DESCRIPTION
bug重现步骤:
1.exec 进入k8s的目标pod,模拟容器异常退出 kill -9 1.让pod重启
2.进入对应节点的log-pilot pod中,发现log-pilot没有清理掉已经重启的pod的日志配置文件,并且生成了一个新的以容器ID命名的配置文件,内容中的path和旧的配置文件一样,从而导致日志出现重复收集

解决:
由于log-pilot缺少监听容器的die事件导致,增加对die事件的监听即可