### PR TITLE
support custom filebeat config

### DIFF
--- a/assets/filebeat/filebeat.tpl
+++ b/assets/filebeat/filebeat.tpl
@@ -12,12 +12,18 @@
   json.keys_under_root: true
   {{end}}
   fields:
+      {{range $key, $value := .CustomFields}}
+      {{ $key }}: {{ $value }}
+      {{end}}
       {{range $key, $value := .Tags}}
       {{ $key }}: {{ $value }}
       {{end}}
       {{range $key, $value := $.container}}
       {{ $key }}: {{ $value }}
       {{end}}
+  {{range $key, $value := .CustomConfigs}}
+  {{ $key }}: {{ $value }}
+  {{end}}
   tail_files: false
   close_inactive: 2h
   close_eof: false

--- a/pilot/piloter.go
+++ b/pilot/piloter.go
@@ -3,6 +3,7 @@ package pilot
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // Global variables for piloter
@@ -37,4 +38,25 @@ func NewPiloter(baseDir string) (Piloter, error) {
 		return NewFluentdPiloter()
 	}
 	return nil, fmt.Errorf("InvalidPilotType")
+}
+
+// CustomConfig custom config
+func CustomConfig(name string, customConfigs map[string]string, logConfig *LogConfig) {
+	if os.Getenv(ENV_PILOT_TYPE) == PILOT_FILEBEAT {
+		fields := make(map[string]string)
+		configs := make(map[string]string)
+		for k, v := range customConfigs {
+			if strings.HasPrefix(k, name) {
+				key := strings.TrimPrefix(k, name+".")
+				if strings.HasPrefix(key, "fields") {
+					key2 := strings.TrimPrefix(key, "fields.")
+					fields[key2] = v
+				} else {
+					configs[key] = v
+				}
+			}
+		}
+		logConfig.CustomFields = fields
+		logConfig.CustomConfigs = configs
+	}
 }


### PR DESCRIPTION
support custom all filebeat config.

ENV **aliyun_logs_custom_config** mount the user defined configs in configmap.

```
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: customconfig
data:
  config: |
    catalina.fields.service=nginx-log
    catalina.multiline.pattern='^\['
    catalina.multiline.negate=true
    catalina.multiline.match=after
---
apiVersion: v1
kind: Pod
metadata:
  name: tomcat
spec:
  containers:
  - name: tomcat
    image: "tomcat:7.0"
    env:
    # 1、stdout为约定关键字，表示采集标准输出日志
    # 2、配置标准输出日志采集到ES的catalina索引下
    - name: aliyun_logs_catalina
      value: "stdout"
    # 1、配置采集容器内文件日志，支持通配符
    # 2、配置该日志采集到ES的access索引下
    - name: aliyun_logs_access
      value: "/usr/local/tomcat/logs/catalina.*.log"
    - name: aliyun_logs_custom_config
      valueFrom:
        configMapKeyRef:
          name: customconfig
          key: config
    # 容器内文件日志路径需要配置emptyDir
    volumeMounts:
    - name: tomcat-log
      mountPath: /usr/local/tomcat/logs
  volumes:
  - name: tomcat-log
    emptyDir: {}
```